### PR TITLE
Device List when no controller found and enumeration optimisations

### DIFF
--- a/Sources/Config.cs
+++ b/Sources/Config.cs
@@ -43,7 +43,7 @@ namespace AltInput
         /// <summary>The maximum number of device instances that can be present in a config file</summary>
         private readonly uint NumDevices = 128;
         // Good developers do NOT let end-users fiddle with XML configuration files...
-        private static IniFile ini = new IniFile(Directory.GetCurrentDirectory() +
+        internal static IniFile ini = new IniFile(Directory.GetCurrentDirectory() +
             @"\Plugins\PluginData\AltInput\config.ini");
         private DirectInput directInput = new DirectInput();
         private static readonly char[] Separators = { '[', ']', ' ', '\t' };

--- a/Sources/Config.cs
+++ b/Sources/Config.cs
@@ -271,7 +271,6 @@ namespace AltInput
         /// </summary>
         void ParseInputs()
         {
-            String InterfaceName, ClassName, DeviceName;
             AltDirectInputDevice Device;
             DeviceClass InstanceClass = DeviceClass.GameControl;
 
@@ -279,38 +278,44 @@ namespace AltInput
             if (iniVersion != currentVersion)
                 return;
 
-            for (var i = 1; i <= NumDevices; i++)
-            {
-                String InputName = "input" + i;
-                InterfaceName = ini.IniReadValue(InputName, "Interface");
-                if ((InterfaceName == "") || (ini.IniReadValue(InputName, "Ignore") == "true"))
-                    continue;
-                if (InterfaceName != "DirectInput")
-                {
-                    print("AltInput[" + InputName + "]: Only 'DirectInput' is supported for Interface type");
-                    continue;
-                }
-                ClassName = ini.IniReadValue(InputName, "Class");
-                if (ClassName == "")
-                    ClassName = "GameControl";
-                else if (ClassName != "GameControl")
-                {
-                    print("AltInput[" + InputName + "]: '" + ClassName + "' is not an allowed Class value");
-                    continue;   // ignore the device
-                }
-                // Overkill for now, but may come handy if we add support for other DirectInput devices
-                foreach (DeviceClass Class in Enum.GetValues(typeof(DeviceClass)))
-                {
-                    if (Enum.GetName(typeof(DeviceClass), Class) == ClassName)
-                    {
-                        InstanceClass = Class;
-                        break;
-                    }
-                }
-                DeviceName = ini.IniReadValue(InputName, "Name");
+            string installeddevicelist = "";
 
-                foreach (var dev in directInput.GetDevices(InstanceClass, DeviceEnumerationFlags.AllDevices))
+            foreach (var dev in directInput.GetDevices(InstanceClass, DeviceEnumerationFlags.AllDevices))
+            {
+                installeddevicelist += System.Environment.NewLine + dev.InstanceName;
+
+                for (var i = 1; i <= NumDevices; i++)
                 {
+                    String InterfaceName, ClassName, DeviceName;
+
+                    String InputName = "input" + i;
+                    InterfaceName = ini.IniReadValue(InputName, "Interface");
+                    if ((InterfaceName == "") || (ini.IniReadValue(InputName, "Ignore") == "true"))
+                        continue;
+                    if (InterfaceName != "DirectInput")
+                    {
+                        print("AltInput[" + InputName + "]: Only 'DirectInput' is supported for Interface type");
+                        continue;
+                    }
+                    ClassName = ini.IniReadValue(InputName, "Class");
+                    if (ClassName == "")
+                        ClassName = "GameControl";
+                    else if (ClassName != "GameControl")
+                    {
+                        print("AltInput[" + InputName + "]: '" + ClassName + "' is not an allowed Class value");
+                        continue;   // ignore the device
+                    }
+                    // Overkill for now, but may come handy if we add support for other DirectInput devices
+                    foreach (DeviceClass Class in Enum.GetValues(typeof(DeviceClass)))
+                    {
+                        if (Enum.GetName(typeof(DeviceClass), Class) == ClassName)
+                        {
+                            InstanceClass = Class;
+                            break;
+                        }
+                    }
+                    DeviceName = ini.IniReadValue(InputName, "Name");
+
                     if ((DeviceName == "") || (dev.InstanceName.Contains(DeviceName)))
                     {
                         // Only add this device if not already in our list
@@ -320,12 +325,13 @@ namespace AltInput
                         SetAttributes(Device, InputName);
                         DeviceList.Add(Device);
                         print("AltInput: Added controller '" + dev.InstanceName + "'");
+                        break;
                     }
                 }
             }
             if (DeviceList.Count == 0)
             {
-                print("AltInput: No controller found");
+                print("AltInput: No configured controller found." + installeddevicelist);
                 return;
             }
         }

--- a/Sources/Config.cs
+++ b/Sources/Config.cs
@@ -35,7 +35,7 @@ namespace AltInput
     /// <summary>
     /// Handles the input device configuration
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    [KSPAddon(KSPAddon.Startup.Instantly, false)]
     public class Config : MonoBehaviour
     {
         public static readonly float currentVersion = 1.3f;
@@ -43,8 +43,9 @@ namespace AltInput
         /// <summary>The maximum number of device instances that can be present in a config file</summary>
         private readonly uint NumDevices = 128;
         // Good developers do NOT let end-users fiddle with XML configuration files...
-        internal static IniFile ini = new IniFile(Directory.GetCurrentDirectory() +
-            @"\Plugins\PluginData\AltInput\config.ini");
+        internal static IniFile ini = new IniFile(
+            System.Reflection.Assembly.GetExecutingAssembly().Location.Substring(0, System.Reflection.Assembly.GetExecutingAssembly().Location.LastIndexOf('\\'))
+            + @"\config.ini");
         private DirectInput directInput = new DirectInput();
         private static readonly char[] Separators = { '[', ']', ' ', '\t' };
         public static List<AltDevice> DeviceList = new List<AltDevice>();

--- a/Sources/Config.cs
+++ b/Sources/Config.cs
@@ -48,6 +48,7 @@ namespace AltInput
         private DirectInput directInput = new DirectInput();
         private static readonly char[] Separators = { '[', ']', ' ', '\t' };
         public static List<AltDevice> DeviceList = new List<AltDevice>();
+        internal static string FoundControllers = "";
 
         private void ParseMapping(String Section, String Name, AltMapping[] Mapping, int mode)
         {
@@ -278,11 +279,11 @@ namespace AltInput
             if (iniVersion != currentVersion)
                 return;
 
-            string installeddevicelist = "";
+            FoundControllers = "";
 
             foreach (var dev in directInput.GetDevices(InstanceClass, DeviceEnumerationFlags.AllDevices))
             {
-                installeddevicelist += System.Environment.NewLine + dev.InstanceName;
+                FoundControllers += System.Environment.NewLine + dev.InstanceName;
 
                 for (var i = 1; i <= NumDevices; i++)
                 {
@@ -331,7 +332,8 @@ namespace AltInput
             }
             if (DeviceList.Count == 0)
             {
-                print("AltInput: No configured controller found." + installeddevicelist);
+                if (FoundControllers == "") FoundControllers = "None Found.";
+                print("AltInput: No configured controller found." + FoundControllers);
                 return;
             }
         }

--- a/Sources/Flight.cs
+++ b/Sources/Flight.cs
@@ -87,7 +87,7 @@ namespace AltInput
             }
             if (Config.DeviceList.Count == 0)
             {
-                ScreenMessages.PostScreenMessage("AltInput: No controller detected", 5f,
+                ScreenMessages.PostScreenMessage("AltInput: No configured controller detected" + Environment.NewLine + "Found controllers:" + Config.FoundControllers, 5f,
                     ScreenMessageStyle.UPPER_LEFT);
                 return;
             }

--- a/Sources/Flight.cs
+++ b/Sources/Flight.cs
@@ -73,9 +73,13 @@ namespace AltInput
             print("AltInput: ProcessInput.Start()");
 #endif
             // TODO: Only list/acquire controller if we have some mapping assigned
-            foreach (var Device in Config.DeviceList)
-                Device.OpenDevice();
-            if (Config.iniVersion != Config.currentVersion) {
+            if (!System.IO.File.Exists(Config.ini.path))
+            {
+                ScreenMessages.PostScreenMessage("AltInput: Config file not found (" + Config.ini.path + ")", 10f, ScreenMessageStyle.UPPER_LEFT);
+                return;
+            }
+            if (Config.iniVersion != Config.currentVersion) 
+            {
                 ScreenMessages.PostScreenMessage("AltInput: Config file ignored due to Version mismatch (Got v" +
                     Config.iniVersion.ToString("F01") + ", required v" + Config.currentVersion.ToString("F01") +
                     ")", 10f, ScreenMessageStyle.UPPER_LEFT);
@@ -87,6 +91,8 @@ namespace AltInput
                     ScreenMessageStyle.UPPER_LEFT);
                 return;
             }
+            foreach (var Device in Config.DeviceList)
+                Device.OpenDevice();
             // Add our handler
             if (FlightGlobals.ActiveVessel != null)
                 FlightGlobals.ActiveVessel.OnFlyByWire += new FlightInputCallback(ControllerInput);


### PR DESCRIPTION
I made some changes to give better feedback when devices/ini files are not found and to make it clear to me whether it was directx not enumerating the device or altinput not finding a config match. Also a test to see if the ini file is found.

A few internal members were needed as flight gives feedback to the user through a screen message but the information is collected by config.

Also reordered the config parseinputs() loops to iterate on directinput.GetDevices(..) rather than looping the config input1... inputx  as this allows earlier termination in the event of a match and doesn't scan the file 128 times if there are no connected controllers.  Should be much more efficient in most common cases and makes collecting the list of connected controllers (FoundDevices) cleaner.
