### PR TITLE
Fix for the B9 too many parts/plugins issue

### DIFF
--- a/Sources/Config.cs
+++ b/Sources/Config.cs
@@ -35,11 +35,12 @@ namespace AltInput
     /// <summary>
     /// Handles the input device configuration
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    [KSPAddon(KSPAddon.Startup.Instantly, false)]
     public class Config : MonoBehaviour
     {
-        public static readonly String ini_path = Directory.GetCurrentDirectory() +
-            @"\Plugins\PluginData\AltInput\config.ini";
+        public static readonly String ini_path 
+            = System.Reflection.Assembly.GetExecutingAssembly().Location.Substring(0, System.Reflection.Assembly.GetExecutingAssembly().Location.LastIndexOf('\\'))
+            + @"\config.ini");
         public static readonly System.Version dllVersion = typeof(AltDevice).Assembly.GetName().Version;
         public static readonly System.Version currentVersion = new System.Version("1.4");
         public static System.Version iniVersion;


### PR DESCRIPTION
These 2 small changes combined seem to fix it! 

Setting it to initialise instantly instead of on mainmenu..
Changing the ini_path to be relative to the executing assembly means the files can be placed anywhere.  

I've got mine in GameData\AltInput as that seems to be the standard.  (not sure if that reflection method is the most efficient way)
I think the order the plugins are discovered matters, it being in a directory beginning with 'A' puts it to the head of the queue.

It's only the dll location that matters but it seems odd to put the ini file somewhere else.
